### PR TITLE
update get_battery_voltage with clear calculation

### DIFF
--- a/code/circuitpython/shipping files/feathers3/feathers3.py
+++ b/code/circuitpython/shipping files/feathers3/feathers3.py
@@ -44,13 +44,14 @@ def set_ldo2_power(state):
     
 def get_battery_voltage():
     """Get the approximate battery voltage."""
-    # I don't really understand what CP is doing under the hood here for the ADC range & calibration,
-    # but the onboard voltage divider for VBAT sense is setup to deliver 1.1V to the ADC based on it's
-    # default factory configuration.
     # This formula should show the nominal 4.2V max capacity (approximately) when 5V is present and the
     # VBAT is in charge state for a 1S LiPo battery with a max capacity of 4.2V   
     global vbat_voltage
-    return (vbat_voltage.value / 5371)
+    ADC_RESOLUTION = 2 ** 16 -1
+    AREF_VOLTAGE = 3.3
+    R1 = 442000
+    R2 = 160000
+    return (vbat_voltage.value/ADC_RESOLUTION*AREF_VOLTAGE*(R1+R2)/R2)
 
 def get_vbus_present():
     """Detect if VBUS (5V) power source is present"""

--- a/code/circuitpython/shipping files/pros3/pros3.py
+++ b/code/circuitpython/shipping files/pros3/pros3.py
@@ -31,13 +31,15 @@ def set_ldo2_power(state):
     
 def get_battery_voltage():
     """Get the approximate battery voltage."""
-    # I don't really understand what CP is doing under the hood here for the ADC range & calibration,
-    # but the onboard voltage divider for VBAT sense is setup to deliver 1.1V to the ADC based on it's
-    # default factory configuration.
     # This formula should show the nominal 4.2V max capacity (approximately) when 5V is present and the
     # VBAT is in charge state for a 1S LiPo battery with a max capacity of 4.2V   
     global vbat_voltage
-    return (vbat_voltage.value / 5371)
+    ADC_RESOLUTION = 2 ** 16 -1
+    AREF_VOLTAGE = 3.3
+    R1 = 442000
+    R2 = 160000
+    return (vbat_voltage.value/ADC_RESOLUTION*AREF_VOLTAGE*(R1+R2)/R2)
+
 
 def get_vbus_present():
     """Detect if VBUS (5V) power source is present"""

--- a/code/circuitpython/shipping files/tinys3/tinys3.py
+++ b/code/circuitpython/shipping files/tinys3/tinys3.py
@@ -31,13 +31,15 @@ def set_pixel_power(state):
     
 def get_battery_voltage():
     """Get the approximate battery voltage."""
-    # I don't really understand what CP is doing under the hood here for the ADC range & calibration,
-    # but the onboard voltage divider for VBAT sense is setup to deliver 1.1V to the ADC based on it's
-    # default factory configuration.
     # This formula should show the nominal 4.2V max capacity (approximately) when 5V is present and the
     # VBAT is in charge state for a 1S LiPo battery with a max capacity of 4.2V   
     global vbat_voltage
-    return (vbat_voltage.value / 5371)
+    ADC_RESOLUTION = 2 ** 16 -1
+    AREF_VOLTAGE = 3.3
+    R1 = 442000
+    R2 = 160000
+    return (vbat_voltage.value/ADC_RESOLUTION*AREF_VOLTAGE*(R1+R2)/R2)
+
 
 def get_vbus_present():
     """Detect if VBUS (5V) power source is present"""


### PR DESCRIPTION
Updates the get_battery_voltage function to return values based on expanded mathematical calculation.  This can be ported to any board by changing the R1 and R2 variables.

In CircuitPython, the voltage on the pin is calculated by the value divided by the ADC resolution multiplied by the reference voltage.  It uses a 16-bit ADC, regardless of what the board supports. So Vin = adc.value / (2^16-1) * 3.3

> ```One important note about this 16-bit range is that it applies even if your board’s ADC has a different resolution (like 10 or 12 bits). Using 16-bits as a base resolution is handy to make code work across many different boards but be aware you might not actually be getting 16-bits of resolution from your ADC. Check your board’s documentation to see the true resolution of its ADC. ```
https://learn.adafruit.com/circuitpython-basics-analog-inputs-and-outputs/analog-to-digital-converter-inputs

Given the formula for voltage dividers, Vout=(Vsource * R2) / (R1 + R2), we can re-write to Vsource = Vout * (R1 + R2) / R2. For the S3 line, R1 is 442000 ohm, and R2 is 160000 ohm.

Combine the two is Vsource = adc.value / (2^16-1) * 3.3 * ( 442000 + 160000 ) / 160000, which simplifies to adc.value / 5278.1637, which is approximately equal to the original code (5371).

